### PR TITLE
♻️ refactor/KIKI-36 : DEV 테스트 파이프라인 성능 개선

### DIFF
--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -34,17 +34,24 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      # 2. gradle 환경 설치
+      # 3. gradle 환경 설치
       - name: Gradle Wrapper 권한 부여
         run: chmod +x gradlew
 
-      # 4. gradle 환경 설치
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+      # 4. 캐싱
+      - name: Gradle Caching
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}
 
       # 5. 빌드
       - name: Build with Gradle Wrapper
-        run: ./gradlew build
+        run: ./gradlew clean build
 
       # 6. JUnit 테스트 결과 게시
       - name: Test 결과 출력


### PR DESCRIPTION
## 📌 작업한 내용  
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- 매번 테스트를 진행할때마다 속도가 매우 느리기에 어떤 것이 문제인가 확인을 해보았더니, Gradle에서 4분 40초가 걸리는 모습을 확인할 수 있었다.
- 파이프라인에서 setGradle의 코드를 Gradle을 캐싱함으로써 속도를 향상 시키도록 바꾸었다.

## 🔍 참고 사항  
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->


## 🖼️ 스크린샷  
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

- 변경 전 
<img width="1485" alt="image" src="https://github.com/user-attachments/assets/14ff7000-11fe-4731-a4c4-485de2bb2f21" />

- 변경 후
<img width="1485" alt="image" src="https://github.com/user-attachments/assets/2e419321-18ef-4eda-a3ce-7070cc35a15e" />

4분 40초에서 2초로 줄어들었다

## 🔗 관련 이슈  
<!-- 연관된 이슈를 적어주세요. -->
KIKI-28
KIKI-36

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [ ] 문서화 필요 여부 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Gradle 캐시 사용을 위한 워크플로우 단계가 추가되었습니다.
  - 빌드 명령어에 clean 단계가 포함되어, `./gradlew clean build`로 변경되었습니다.
  - 워크플로우 단계 번호가 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->