### PR TITLE
✨feat/KIKI-48 : Slice 기반 무한스크롤 목록 조회 구현

### DIFF
--- a/src/main/java/com/jiyoung/kikihi/global/response/page/SliceResponse.java
+++ b/src/main/java/com/jiyoung/kikihi/global/response/page/SliceResponse.java
@@ -1,0 +1,23 @@
+package com.jiyoung.kikihi.global.response.page;
+
+import lombok.Builder;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+@Builder
+public record SliceResponse<T>(
+        List<T> content,
+        boolean hasNext,
+        int page,
+        int size
+) {
+    public static <T> SliceResponse<T> from(Slice<T> slice) {
+        return SliceResponse.<T>builder()
+                .content(slice.getContent())
+                .hasNext(slice.hasNext())
+                .page(slice.getNumber() + 1)
+                .size(slice.getSize())
+                .build();
+    }
+}

--- a/src/main/java/com/jiyoung/kikihi/platform/adapter/in/web/ProductController.java
+++ b/src/main/java/com/jiyoung/kikihi/platform/adapter/in/web/ProductController.java
@@ -3,16 +3,14 @@ package com.jiyoung.kikihi.platform.adapter.in.web;
 import com.jiyoung.kikihi.global.response.ApiResponse;
 import com.jiyoung.kikihi.global.response.ErrorCode;
 import com.jiyoung.kikihi.global.response.page.PageRequest;
-import com.jiyoung.kikihi.global.response.page.PageResponse;
+import com.jiyoung.kikihi.global.response.page.SliceResponse;
 import com.jiyoung.kikihi.platform.adapter.in.web.dto.response.product.ProductDetailResponse;
 import com.jiyoung.kikihi.platform.adapter.in.web.dto.response.product.ProductListResponse;
 import com.jiyoung.kikihi.platform.adapter.in.web.swagger.ProductControllerSpec;
 import com.jiyoung.kikihi.platform.application.in.product.ProductUseCase;
 import com.jiyoung.kikihi.platform.domain.product.Product;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.*;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -34,11 +32,11 @@ public class ProductController implements ProductControllerSpec {
     /// 상품 목록 조회 API
     //  상품 목록 조회 & 필터링 - mongoDB
     @GetMapping("/list")
-    public ApiResponse<PageResponse<ProductListResponse>> getProductList(PageRequest pageRequest,
-                                                                         @RequestParam String category,
-                                                                         @RequestParam(required = false) List<String> manufacturer,
-                                                                         @RequestParam(required = false) Integer minPrice,
-                                                                         @RequestParam(required = false) Integer maxPrice) {
+    public ApiResponse<SliceResponse<ProductListResponse>> getProductList(PageRequest pageRequest,
+                                                                          @RequestParam String category,
+                                                                          @RequestParam(required = false) List<String> manufacturer,
+                                                                          @RequestParam(required = false) Integer minPrice,
+                                                                          @RequestParam(required = false) Integer maxPrice) {
 
         /// Pageable
         Pageable pageable = org.springframework.data.domain.PageRequest.of(
@@ -48,7 +46,7 @@ public class ProductController implements ProductControllerSpec {
         );
 
         /// 파라미터에 따라서 분기
-        Page<Product> products;
+        Slice<Product> products;
 
         // 파라미터 여부에 따라 분기 처리
         if (manufacturer == null && minPrice == null && maxPrice == null) {
@@ -77,7 +75,10 @@ public class ProductController implements ProductControllerSpec {
         /// DTO 변환
         List<ProductListResponse> responses = ProductListResponse.from(productList);
 
-        return ApiResponse.ok(new PageResponse<>(responses, pageRequest, responses.size()));
+        /// 슬라이싱 재생성
+        SliceImpl<ProductListResponse> slice = new SliceImpl<>(responses, pageable, products.hasNext());
+
+        return ApiResponse.ok(SliceResponse.from(slice));
     }
 
     /// 상품 상세 조회 API

--- a/src/main/java/com/jiyoung/kikihi/platform/adapter/in/web/swagger/ProductControllerSpec.java
+++ b/src/main/java/com/jiyoung/kikihi/platform/adapter/in/web/swagger/ProductControllerSpec.java
@@ -2,7 +2,7 @@ package com.jiyoung.kikihi.platform.adapter.in.web.swagger;
 
 import com.jiyoung.kikihi.global.response.ApiResponse;
 import com.jiyoung.kikihi.global.response.page.PageRequest;
-import com.jiyoung.kikihi.global.response.page.PageResponse;
+import com.jiyoung.kikihi.global.response.page.SliceResponse;
 import com.jiyoung.kikihi.platform.adapter.in.web.dto.response.product.ProductDetailResponse;
 import com.jiyoung.kikihi.platform.adapter.in.web.dto.response.product.ProductListResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,7 +28,7 @@ public interface ProductControllerSpec {
             summary = "상품 목록 조회 API",
             description = "파라미터에 따라서 상품 목록을 조회할 수 있습니다."
     )
-    ApiResponse<PageResponse<ProductListResponse>> getProductList(
+    ApiResponse<SliceResponse<ProductListResponse>> getProductList(
             PageRequest pageRequest,
 
             @Parameter(description = "카테고리", required = true, example = "keycap")

--- a/src/main/java/com/jiyoung/kikihi/platform/adapter/out/ProductMongoAdapter.java
+++ b/src/main/java/com/jiyoung/kikihi/platform/adapter/out/ProductMongoAdapter.java
@@ -1,6 +1,5 @@
 package com.jiyoung.kikihi.platform.adapter.out;
 
-import com.jiyoung.kikihi.platform.adapter.out.elasticSearch.ProductESRepository;
 import com.jiyoung.kikihi.platform.adapter.out.mongo.product.ProductDocument;
 import com.jiyoung.kikihi.platform.adapter.out.mongo.product.ProductDocumentRepository;
 import com.jiyoung.kikihi.platform.application.out.product.ProductPort;
@@ -8,6 +7,7 @@ import com.jiyoung.kikihi.platform.domain.product.Product;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -37,10 +37,10 @@ public class ProductMongoAdapter implements ProductPort {
 
     // 카테고리 기반 상품 목록 조회 (카테고리만)
     @Override
-    public Page<Product> getProducts(String category, Pageable pageable) {
+    public Slice<Product> getProducts(String category, Pageable pageable) {
 
         /// DB 조회
-        Page<ProductDocument> result = documentRepository
+        Slice<ProductDocument> result = documentRepository
                 .findByCategory(category, pageable);
 
         return result.
@@ -49,7 +49,7 @@ public class ProductMongoAdapter implements ProductPort {
 
     // 카테고리 기반 상품 목록 조회 (카테고리, 제조사 포함)
     @Override
-    public Page<Product> getProducts(String category, List<String> manufacturer, Pageable pageable) {
+    public Slice<Product> getProducts(String category, List<String> manufacturer, Pageable pageable) {
 
         /// DB 조회
         Page<ProductDocument> result = documentRepository
@@ -61,9 +61,9 @@ public class ProductMongoAdapter implements ProductPort {
 
     // 카테고리 기반 상품 목록 조회 (카테고리, 가격 포함)
     @Override
-    public Page<Product> getProducts(String category, Integer minPrice, Integer maxPrice, Pageable pageable) {
+    public Slice<Product> getProducts(String category, Integer minPrice, Integer maxPrice, Pageable pageable) {
         /// DB 조회
-        Page<ProductDocument> result = documentRepository
+        Slice<ProductDocument> result = documentRepository
                 .findByCategoryAndPriceRange(category, minPrice, maxPrice, pageable);
 
         return result.
@@ -72,11 +72,11 @@ public class ProductMongoAdapter implements ProductPort {
 
     // 카테고리 기반 상품 목록 조회 (카테고리, 제조사, 가격 포함)
     @Override
-    public Page<Product> getProducts(String category, List<String> manufacturer,
+    public Slice<Product> getProducts(String category, List<String> manufacturer,
                                      Integer minPrice, Integer maxPrice, Pageable pageable) {
 
         /// DB 조회
-        Page<ProductDocument> result = documentRepository
+        Slice<ProductDocument> result = documentRepository
                 .findByCategoryAndManufacturerAndPriceRange(category, manufacturer, minPrice, maxPrice, pageable);
 
         return result.

--- a/src/main/java/com/jiyoung/kikihi/platform/adapter/out/mongo/product/ProductDocumentRepository.java
+++ b/src/main/java/com/jiyoung/kikihi/platform/adapter/out/mongo/product/ProductDocumentRepository.java
@@ -2,6 +2,7 @@ package com.jiyoung.kikihi.platform.adapter.out.mongo.product;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 
@@ -9,7 +10,7 @@ import java.util.List;
 
 public interface ProductDocumentRepository extends MongoRepository<ProductDocument, String> {
 
-    Page<ProductDocument> findByCategory(String category, Pageable pageable);
+    Slice<ProductDocument> findByCategory(String category, Pageable pageable);
 
     // 카테고리 기반 목록 조회 (카테고리, 제조사 포함)
     @Query("{ 'category': ?0, 'spec_table.제조회사': { $in: ?1 } }")
@@ -22,7 +23,7 @@ public interface ProductDocumentRepository extends MongoRepository<ProductDocume
       'price': { $gte: ?1, $lte: ?2 }
     }
     """)
-    Page<ProductDocument> findByCategoryAndPriceRange(
+    Slice<ProductDocument> findByCategoryAndPriceRange(
             String category,
             Integer minPrice,
             Integer maxPrice,
@@ -37,7 +38,7 @@ public interface ProductDocumentRepository extends MongoRepository<ProductDocume
       'price': { $gte: ?2, $lte: ?3 }
     }
     """)
-    Page<ProductDocument> findByCategoryAndManufacturerAndPriceRange(
+    Slice<ProductDocument> findByCategoryAndManufacturerAndPriceRange(
             String category,
             List<String> manufacturer,
             Integer minPrice,

--- a/src/main/java/com/jiyoung/kikihi/platform/application/in/product/ProductUseCase.java
+++ b/src/main/java/com/jiyoung/kikihi/platform/application/in/product/ProductUseCase.java
@@ -1,8 +1,8 @@
 package com.jiyoung.kikihi.platform.application.in.product;
 
 import com.jiyoung.kikihi.platform.domain.product.Product;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 import java.util.*;
 
@@ -21,16 +21,16 @@ public interface ProductUseCase {
     List<Product> getProducts();
 
     // 카테고리별 목록 조회 (카테고리 포함) - mongoDB
-    Page<Product> getProductsByCategoryId(String categoryId, Pageable pageable);
+    Slice<Product> getProductsByCategoryId(String categoryId, Pageable pageable);
 
     // 카테고리별 목록 조회 (카테고리, 제조사 포함)
-    Page<Product> getProductsByCategoryIdAndManufacturerId(String categoryId, List<String> manufacturerId, Pageable pageable);
+    Slice<Product> getProductsByCategoryIdAndManufacturerId(String categoryId, List<String> manufacturerId, Pageable pageable);
 
     // 카테고리별 목록 조회 (카테고리, 가격 포함)
-    Page<Product> getProductsByCategoryIdAndPrice(String categoryId, Integer minPrice, Integer maxPrice, Pageable pageable);
+    Slice<Product> getProductsByCategoryIdAndPrice(String categoryId, Integer minPrice, Integer maxPrice, Pageable pageable);
 
     // 카테고리별 목록 조회 (카테고리, 제조사, 가격 포함)
-    Page<Product> getProductsByCategoryIdAndManufacturerIdAndPrice(String categoryId, List<String> manufacturer, Integer minPrice, Integer maxPrice, Pageable pageable);
+    Slice<Product> getProductsByCategoryIdAndManufacturerIdAndPrice(String categoryId, List<String> manufacturer, Integer minPrice, Integer maxPrice, Pageable pageable);
 
     /// 상품 상세 조회
     Product getProduct(String id);

--- a/src/main/java/com/jiyoung/kikihi/platform/application/out/product/ProductPort.java
+++ b/src/main/java/com/jiyoung/kikihi/platform/application/out/product/ProductPort.java
@@ -1,8 +1,8 @@
 package com.jiyoung.kikihi.platform.application.out.product;
 
 import com.jiyoung.kikihi.platform.domain.product.Product;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 import java.util.*;
 
@@ -20,16 +20,16 @@ public interface ProductPort {
     List<Product> getProducts();
 
     // 카테고리 기반 상품 목록 조회 (카테고리만)
-    Page<Product> getProducts(String category, Pageable pageable);
+    Slice<Product> getProducts(String category, Pageable pageable);
 
     // 카테고리 기반 상품 목록 조회 (카테고리, 제조사 포함)
-    Page<Product> getProducts(String category, List<String> manufacturer, Pageable pageable);
+    Slice<Product> getProducts(String category, List<String> manufacturer, Pageable pageable);
 
     // 카테고리 기반 상품 목록 조회 (카테고리, 제조사 포함)
-    Page<Product> getProducts(String category, Integer minPrice, Integer maxPrice, Pageable pageable);
+    Slice<Product> getProducts(String category, Integer minPrice, Integer maxPrice, Pageable pageable);
 
     // 카테고리 기반 상품 목록 조회 (카테고리, 제조사, 가격 포함)
-    Page<Product> getProducts(String category, List<String> manufacturer, Integer minPrice, Integer maxPrice, Pageable pageable);
+    Slice<Product> getProducts(String category, List<String> manufacturer, Integer minPrice, Integer maxPrice, Pageable pageable);
 
     /// 삭제
     void deleteProduct(String productId);

--- a/src/main/java/com/jiyoung/kikihi/platform/application/service/ProductService.java
+++ b/src/main/java/com/jiyoung/kikihi/platform/application/service/ProductService.java
@@ -6,8 +6,8 @@ import com.jiyoung.kikihi.platform.application.out.product.ProductPort;
 import com.jiyoung.kikihi.platform.domain.product.Product;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,7 +31,7 @@ public class ProductService implements ProductUseCase {
 
     // 카테고리별 목록 조회 (카테고리 포함) - mongoDB
     @Override
-    public Page<Product> getProductsByCategoryId(String categoryId, Pageable pageable) {
+    public Slice<Product> getProductsByCategoryId(String categoryId, Pageable pageable) {
 
         /// 카테고리를 바탕으로 조회
         return productPort.getProducts(categoryId, pageable);
@@ -39,14 +39,14 @@ public class ProductService implements ProductUseCase {
 
     // 카테고리별 목록 조회 (카테고리, 제조사 포함)
     @Override
-    public Page<Product> getProductsByCategoryIdAndManufacturerId(String categoryId, List<String> manufacturers, Pageable pageable) {
+    public Slice<Product> getProductsByCategoryIdAndManufacturerId(String categoryId, List<String> manufacturers, Pageable pageable) {
 
         return productPort.getProducts(categoryId, manufacturers, pageable);
     }
 
     // 카테고리별 목록 조회 (카테고리, 가격 포함)
     @Override
-    public Page<Product> getProductsByCategoryIdAndPrice(String categoryId, Integer minPrice, Integer maxPrice, Pageable pageable) {
+    public Slice<Product> getProductsByCategoryIdAndPrice(String categoryId, Integer minPrice, Integer maxPrice, Pageable pageable) {
 
         return productPort.getProducts(categoryId, minPrice, maxPrice, pageable);
     }
@@ -54,7 +54,7 @@ public class ProductService implements ProductUseCase {
 
     // 카테고리별 목록 조회 (카테고리, 제조사, 가격 포함)
     @Override
-    public Page<Product> getProductsByCategoryIdAndManufacturerIdAndPrice(String categoryId, List<String> manufacturers, Integer minPrice, Integer maxPrice, Pageable pageable) {
+    public Slice<Product> getProductsByCategoryIdAndManufacturerIdAndPrice(String categoryId, List<String> manufacturers, Integer minPrice, Integer maxPrice, Pageable pageable) {
 
         return productPort.getProducts(categoryId, manufacturers, minPrice, maxPrice, pageable);
     }


### PR DESCRIPTION
## 📌 작업한 내용  
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- Slice 기반 페이징 API 구현을 통해 무한스크롤 목록 조회 기능 추가
- PageRequest를 기반으로 클라이언트에서 요청한 페이지 및 사이즈 처리
- 카테고리, 제조사, 가격 필터링 조건에 따라 동적 조회 가능
- 기존 응답을 DTO 변환 후, 커스텀 SliceResponse로 감싸 반환

## 🔍 참고 사항  
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->
[ 프론트엔드에서는 hasNext 값을 활용하여 추가 페이지 요청 여부를 판단할 수 있습니다.
- 기존 Page 기반에서 Slice로 변경되었기 때문에, 전체 count가 필요 없는 성능 개선형 API입니다.

## 🖼️ 스크린샷  
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

요청이 더 있는 경우-> hasNext : true
![image](https://github.com/user-attachments/assets/69fd4b96-e197-4d90-9b18-7a0d39c62af2)

요청이 더 있는 경우-> hasNext : false
![image](https://github.com/user-attachments/assets/d5914bc7-8647-4eb4-8565-b23a3d261a1d)

## 🔗 관련 이슈  
<!-- 연관된 이슈를 적어주세요. -->
#26 

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [x] 문서화 필요 여부 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 상품 목록 조회 시 페이지네이션 응답이 기존 Page 기반에서 Slice 기반으로 개선되었습니다. 이제 상품 목록 API에서 다음 페이지 존재 여부와 현재 페이지 정보를 더욱 직관적으로 확인할 수 있습니다.

* **버그 수정**
  * 없음

* **문서화**
  * 없음

* **리팩터링**
  * 없음

* **스타일**
  * 없음

* **테스트**
  * 없음

* **기타 작업**
  * 없음

<!-- end of auto-generated comment: release notes by coderabbit.ai -->