### PR TITLE
🔥️ fix/KIKI-64 : 북마크 내용 DTO 포함 안되는 오류 해결 및 상세조회 삭제

### DIFF
--- a/src/main/java/com/jiyoung/kikihi/platform/adapter/in/web/BookmarkController.java
+++ b/src/main/java/com/jiyoung/kikihi/platform/adapter/in/web/BookmarkController.java
@@ -50,23 +50,7 @@ public class BookmarkController implements BookmarkControllerSpec {
     }
 
     /**
-     * 북마크 상세 정보를 조회합니다.
-     *
-     * @param id 북마크 ID (PathVariable)
-     * @return 북마크 상세 응답 DTO
-     */
-    @GetMapping("/{id}")
-    public ApiResponse<BookmarkResponse> loadBookmark(@PathVariable Long id) {
-
-        // 서비스 계층
-        BookmarkResponse response = service.loadBookmarkById(id);
-
-        // 리턴
-        return ApiResponse.ok(response);
-    }
-
-    /**
-     * 카테고리별 북마크 목록을 조회합니다.
+     * 나의 북마크 목록을 조회합니다.
      *
      * @param principalDetails 인증된 사용자 정보
      * @param category         카테고리명 (Query Parameter)

--- a/src/main/java/com/jiyoung/kikihi/platform/adapter/in/web/dto/response/bookmark/BookmarkResponse.java
+++ b/src/main/java/com/jiyoung/kikihi/platform/adapter/in/web/dto/response/bookmark/BookmarkResponse.java
@@ -25,7 +25,7 @@ public record BookmarkResponse(
         return BookmarkResponse.builder()
                 .id(bookmark.getId())
                 .userId(bookmark.getUserId())
-                .products(ProductListResponse.from(product))
+                .products(ProductListResponse.from(product, true))
                 .build();
     }
 }

--- a/src/main/java/com/jiyoung/kikihi/platform/adapter/in/web/dto/response/product/ProductListResponse.java
+++ b/src/main/java/com/jiyoung/kikihi/platform/adapter/in/web/dto/response/product/ProductListResponse.java
@@ -62,7 +62,7 @@ public record ProductListResponse(
     }
 
     /// 북마크한 내용이 있을 때 사용하는, 내부 정적 팩토리 메서드
-    private static ProductListResponse from(Product product, boolean likedByMe) {
+    public static ProductListResponse from(Product product, boolean likedByMe) {
         return ProductListResponse.builder()
                 .id(product.getId())
                 .thumbnail(product.getThumbnail())

--- a/src/main/java/com/jiyoung/kikihi/platform/adapter/in/web/swagger/BookmarkControllerSpec.java
+++ b/src/main/java/com/jiyoung/kikihi/platform/adapter/in/web/swagger/BookmarkControllerSpec.java
@@ -49,30 +49,14 @@ public interface BookmarkControllerSpec {
 
 
     /**
-     * 북마크 상세 정보를 조회합니다.
-     *
-     * @param id 북마크 ID
-     * @return 북마크 상세 DTO
-     */
-    @Operation(
-            summary = "북마크 상세 조회 API",
-            description = "북마크 ID를 기반으로 조회할 수 있습니다."
-    )
-    ApiResponse<BookmarkResponse> loadBookmark(
-            @Parameter(description = "북마크 Id", example = "1")
-            @PathVariable Long id);
-
-
-
-    /**
-     * 카테고리별 북마크 목록을 조회합니다.
+     * 나의 카테고리별 북마크 목록을 조회합니다.
      *
      * @param principalDetails 인증 정보
      * @param category         카테고리명
      * @return 북마크 목록 DTO 리스트
      */
     @Operation(
-            summary = "카테고리 기반 북마크 목록 조회 API",
+            summary = "나의 북마크 목록 조회 API",
             description = "JWT 기반으로 카테고리별 북마크 목록을 조회할 수 있습니다."
     )
     ApiResponse<SliceResponse<BookmarkResponse>> loadBookmarkByCategory(

--- a/src/main/java/com/jiyoung/kikihi/platform/application/in/bookmark/BookmarkUseCase.java
+++ b/src/main/java/com/jiyoung/kikihi/platform/application/in/bookmark/BookmarkUseCase.java
@@ -22,9 +22,6 @@ public interface BookmarkUseCase {
     /// 저장하기
     Bookmark saveBookmark(BookmarkRequest request);
 
-    /// 조회하기
-    BookmarkResponse loadBookmarkById(Long id);
-
     Slice<BookmarkResponse> loadBookmarksByUserIdAndCategory(UUID userId, String category, Pageable pageable);
 
     /// 삭제하기

--- a/src/main/java/com/jiyoung/kikihi/platform/application/service/BookmarkService.java
+++ b/src/main/java/com/jiyoung/kikihi/platform/application/service/BookmarkService.java
@@ -58,27 +58,8 @@ public class BookmarkService implements BookmarkUseCase {
         return port.saveBookmark(bookmark);
     }
 
-
     /**
-     * 북마크 상세 조회
-     * @param id 조회할 북마크 Id
-     */
-    @Override
-    public BookmarkResponse loadBookmarkById(Long id) {
-        /// 북마크 조회
-        Bookmark bookmark = port.getBookmark(id)
-                .orElseThrow(() -> new NoSuchElementException(ErrorCode.BOOKMARK_NOT_FOUND.getMessage()));
-
-        // 상품 가져오기
-        Product product = productPort.getProduct(bookmark.getProductId())
-                .orElseThrow(() -> new NoSuchElementException(ErrorCode.PRODUCT_NOT_FOUND.getMessage()));
-
-        return BookmarkResponse.from(bookmark, product);
-
-    }
-
-    /**
-     * 카테고리 기반 북마크 조회
+     * 나의 북마크 조회
      * @param userId    북마크 조회할 유저 Id
      * @param category  조회할 상품 카테고리
      */
@@ -93,7 +74,7 @@ public class BookmarkService implements BookmarkUseCase {
         // TODO: 추후 카테고리를 Enum으로 변경후 진행할 예정입니다.
 
         // 유저를 바탕으로 해당 카테고리를 가진 아이템 목록 조회
-        List<Bookmark> bookmarks = port.getBookmarksByUserIdAndCategoryId(userId, category);
+        List<Bookmark> bookmarks = port.getBookmarksByUserIdAndCategoryId(user.getId(), category);
 
         // 상품 Id 목록 가져오기
         List<String> productIds = getProductIds(bookmarks);

--- a/src/test/java/com/jiyoung/kikihi/platform/application/service/BookmarkServiceIntTest.java
+++ b/src/test/java/com/jiyoung/kikihi/platform/application/service/BookmarkServiceIntTest.java
@@ -189,34 +189,36 @@ class BookmarkServiceIntTest {
         }
 
         @Test
-        @DisplayName("[happy] Id기반으로 북마크 상세 조회")
-        void loadBookmark_정상_조회() {
+        @DisplayName("[happy] 북마크에 좋아요 여부 true 표시")
+        void loadBookmark_좋아요_정상_조회() {
 
             // given
-            var request = BookmarkRequest.builder()
-                    .userId(user.getId())
-                    .productId(product1.getId())
-                    .build();
-            Bookmark saveBookmark = sut.saveBookmark(request);
+            Pageable pageable = PageRequest.of(0, 10);
+            List<Bookmark> savedBookmarks = new ArrayList<>();
+
+            /// 3개의 상품에 북마크 저장
+            List.of(product1, product2, product3).forEach(product -> {
+                var request = BookmarkRequest.builder()
+                        .userId(user.getId())
+                        .productId(product.getId())
+                        .build();
+                savedBookmarks.add(sut.saveBookmark(request));
+            });
 
             // when
-            BookmarkResponse response = sut.loadBookmarkById(saveBookmark.getId());
+            Slice<BookmarkResponse> bookmarks = sut.loadBookmarksByUserIdAndCategory(user.getId(), "test", pageable);
 
             // then
-            Assertions.assertThat(response.products().id()).isEqualTo(product1.getId());
-        }
+            Assertions.assertThat(bookmarks).hasSize(3);
+            Assertions.assertThat(bookmarks)
+                    .extracting(BookmarkResponse::products)
+                    .extracting(ProductListResponse::id)
+                    .containsExactlyInAnyOrder(product1.getId(), product2.getId(), product3.getId());
+            Assertions.assertThat(bookmarks)
+                    .extracting(BookmarkResponse::products)
+                    .extracting(ProductListResponse::likedByMe)
+                    .containsExactlyInAnyOrder(true, true, true);
 
-        @Test
-        @DisplayName("[unhappy] 북마크 상세 조회 실패")
-        void loadBookmark_throw_NoSuchException() {
-
-            // given
-            Long fakeId = 999L;
-
-            // when & then
-            Assertions.assertThatThrownBy(() -> sut.loadBookmarkById(fakeId))
-                    .isInstanceOf(NoSuchElementException.class)
-                    .hasMessageContaining(ErrorCode.BOOKMARK_NOT_FOUND.getMessage());
         }
     }
 


### PR DESCRIPTION
## 📌 작업한 내용  
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
🔥️ fix/KIKI-64 : 북마크 상세 조회 시 DTO에 북마크 내용이 포함되지 않는 오류를 수정하였습니다.
또한, 사용되지 않는 상세 조회 API를 삭제하여 코드 정리를 진행했습니다.

## 🔍 참고 사항  
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->
- 북마크 목록 조회에서는 정상적으로 내용이 출력되었으나, 단일 북마크 조회 시 응답 DTO에서 likedByMe가 누락되는 이슈가 있었습니다.
- 북마크 상세 API는 현재 FE에서 사용하지 않으며, 정책적으로도 목록에서 모두 제공되기 때문에 제거하였습니다.

## 🖼️ 스크린샷  
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

## 🔗 관련 이슈  
<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료  
- [x] 코드 리뷰 반영 완료  
- [x] 문서화 필요 여부 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **기능 변경**
  * 개별 북마크 상세 조회 기능이 제거되었습니다.
  * 북마크 목록 조회가 "내 북마크" 중심으로 안내 및 동작이 변경되었습니다.

* **버그 수정**
  * 북마크 목록 조회 시, 각 상품의 "좋아요" 상태가 올바르게 표시됩니다.

* **문서**
  * API 설명 및 안내 문구가 "내 북마크" 중심으로 수정되었습니다.

* **테스트**
  * 북마크 "좋아요" 상태 검증 테스트로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->