### PR TITLE
♻️ refactor/response/KIKI-72 : 폴더 재구조화

### DIFF
--- a/src/main/java/com/jiyoung/kikihi/global/config/swagger/LocalSwaggerConfig.java
+++ b/src/main/java/com/jiyoung/kikihi/global/config/swagger/LocalSwaggerConfig.java
@@ -3,11 +3,16 @@ package com.jiyoung.kikihi.global.config.swagger;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+
+import java.util.Map;
+import java.util.TreeMap;
 
 @Configuration
 @Profile("dev")
@@ -34,5 +39,23 @@ public class LocalSwaggerConfig {
                 .version("1.0")
                 .title("키키하이 API")
                 .description("키키하이 로컬 서버의 API 입니다");
+    }
+
+    @Bean
+    public OpenApiCustomizer removeGenericSchemas() {
+        return openApi -> {
+            openApi.getComponents().getSchemas().keySet().removeIf(name ->
+                    name.contains("ApiResponse") || name.contains("SliceResponse")
+            );
+        };
+    }
+    /// 스키마 이름 기준 오름차순
+
+    @Bean
+    public OpenApiCustomizer sortSchemasAlphabetically() {
+        return openApi -> {
+            Map<String, Schema> schemas = openApi.getComponents().getSchemas();
+            openApi.getComponents().setSchemas(new TreeMap<>(schemas));
+        };
     }
 }

--- a/src/main/java/com/jiyoung/kikihi/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/jiyoung/kikihi/global/config/swagger/SwaggerConfig.java
@@ -1,16 +1,20 @@
 package com.jiyoung.kikihi.global.config.swagger;
 
-import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.beans.factory.annotation.Value;
+
+import java.util.Map;
+import java.util.TreeMap;
 
 @Configuration
 @Profile("prod")
@@ -46,5 +50,23 @@ public class SwaggerConfig {
                 .version("1.0")
                 .title("키키하이 API")
                 .description("키키하이 개발 서버의 API 입니다");
+    }
+
+    @Bean
+    public OpenApiCustomizer removeGenericSchemas() {
+        return openApi -> {
+            openApi.getComponents().getSchemas().keySet().removeIf(name ->
+                    name.contains("ApiResponse") || name.contains("SliceResponse")
+            );
+        };
+    }
+    /// 스키마 이름 기준 오름차순
+
+    @Bean
+    public OpenApiCustomizer sortSchemasAlphabetically() {
+        return openApi -> {
+            Map<String, Schema> schemas = openApi.getComponents().getSchemas();
+            openApi.getComponents().setSchemas(new TreeMap<>(schemas));
+        };
     }
 }

--- a/src/main/java/com/jiyoung/kikihi/security/config/CorsConfig.java
+++ b/src/main/java/com/jiyoung/kikihi/security/config/CorsConfig.java
@@ -1,4 +1,4 @@
-package com.jiyoung.kikihi.global.config;
+package com.jiyoung.kikihi.security.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/jiyoung/kikihi/security/config/SecurityConfig.java
+++ b/src/main/java/com/jiyoung/kikihi/security/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.jiyoung.kikihi.global.config;
+package com.jiyoung.kikihi.security.config;
 
 
 import com.jiyoung.kikihi.security.jwt.filter.JwtAuthenticationDeniedHandler;


### PR DESCRIPTION
## 📌 작업한 내용  
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
보안 관련 파일 디렉토리 정리
- global/config 폴더 내의 보안 관련 파일을 security/config로 이동했습니다.

스웨거 관련 DTO 정리 기능 추가
-스웨거 문서화에 필요한 DTO 정리 기능을 추가하였습니다.

## 🔍 참고 사항  
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->


## 🖼️ 스크린샷  
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
x

## 🔗 관련 이슈  
<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [x] 문서화 필요 여부 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * Swagger UI에서 OpenAPI 스키마 정의가 알파벳 순으로 정렬되고, "ApiResponse" 또는 "SliceResponse"가 포함된 스키마 항목이 표시되지 않도록 개선되었습니다.

* **리팩터링**
  * 일부 보안 설정 관련 파일의 패키지 위치가 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->