### PR TITLE
♻️ refactor/Product/KIKI-48 : 상품 및 검색 관련 목록조회 수정

### DIFF
--- a/.github/workflows/dev-ci-cd.yml
+++ b/.github/workflows/dev-ci-cd.yml
@@ -9,7 +9,7 @@ name: 키키하이 dev CI-CD 파이프라인
 
 on:
   push:
-    branches: [ "develop","feat/product/KIKI-48-Product"]
+    branches: [ "develop"]
 
 jobs:
   #1. 개발 서버 CI, Build 용

--- a/.github/workflows/dev-ci-cd.yml
+++ b/.github/workflows/dev-ci-cd.yml
@@ -9,7 +9,7 @@ name: 키키하이 dev CI-CD 파이프라인
 
 on:
   push:
-    branches: [ "develop"]
+    branches: [ "develop","feat/product/KIKI-48-Product"]
 
 jobs:
   #1. 개발 서버 CI, Build 용

--- a/src/main/java/site/kikihi/custom/global/response/page/SliceResponse.java
+++ b/src/main/java/site/kikihi/custom/global/response/page/SliceResponse.java
@@ -1,12 +1,18 @@
 package site.kikihi.custom.global.response.page;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import org.springframework.data.domain.Slice;
 
 import java.util.List;
 
+/// null 값은 직렬화에서 제외
+
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record SliceResponse<T>(
+
+        long totalCount,
         List<T> content,
         boolean hasNext,
         int page,
@@ -20,4 +26,15 @@ public record SliceResponse<T>(
                 .size(slice.getSize())
                 .build();
     }
+
+    public static <T> SliceResponse<T> from(Slice<T> slice, long totalCount) {
+        return SliceResponse.<T>builder()
+                .totalCount(totalCount)
+                .content(slice.getContent())
+                .hasNext(slice.hasNext())
+                .page(slice.getNumber() + 1)
+                .size(slice.getSize())
+                .build();
+    }
+
 }

--- a/src/main/java/site/kikihi/custom/global/response/page/SliceResponse.java
+++ b/src/main/java/site/kikihi/custom/global/response/page/SliceResponse.java
@@ -12,7 +12,7 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record SliceResponse<T>(
 
-        long totalCount,
+        Long totalCount,
         List<T> content,
         boolean hasNext,
         int page,
@@ -20,6 +20,7 @@ public record SliceResponse<T>(
 ) {
     public static <T> SliceResponse<T> from(Slice<T> slice) {
         return SliceResponse.<T>builder()
+                .totalCount(null)
                 .content(slice.getContent())
                 .hasNext(slice.hasNext())
                 .page(slice.getNumber() + 1)

--- a/src/main/java/site/kikihi/custom/platform/adapter/in/web/DevAuthController.java
+++ b/src/main/java/site/kikihi/custom/platform/adapter/in/web/DevAuthController.java
@@ -74,7 +74,6 @@ public class DevAuthController implements DevAuthControllerSpec {
                 .provider(Provider.KAKAO) // 테스트용 값 (Enum)
                 .role(Role.ADMIN) // 관리자 권한 부여
                 .address(Address.of())
-                .isSearch(true)
                 .build();
     }
 

--- a/src/main/java/site/kikihi/custom/platform/adapter/in/web/ProductController.java
+++ b/src/main/java/site/kikihi/custom/platform/adapter/in/web/ProductController.java
@@ -57,6 +57,7 @@ public class ProductController implements ProductControllerSpec {
                 Sort.by(Sort.Direction.DESC, "id")
         );
 
+
         /// 공통 객체들 저장
         Slice<ProductListResponse> products;
 
@@ -84,7 +85,10 @@ public class ProductController implements ProductControllerSpec {
             throw new IllegalArgumentException(ErrorCode.BAD_REQUEST.getMessage());
         }
 
-        return ApiResponse.ok(SliceResponse.from(products));
+        /// 카테고리에 따른 전체 개수 조회
+        Long totalCounts = productService.getCountProducts(category.getValue());
+
+        return ApiResponse.ok(SliceResponse.from(products, totalCounts));
     }
 
     /**
@@ -127,23 +131,6 @@ public class ProductController implements ProductControllerSpec {
 
         /// SliceResponse 변환 후, 리턴
         return ApiResponse.ok(SliceResponse.from(responses));
-    }
-
-
-    /**
-     * 전체 상품 개수 조회 API
-     * @param category  카테 고리
-     */
-    @GetMapping("/total")
-    public ApiResponse<Long> getTotalProducts(
-            @RequestParam CategoryType category
-    ) {
-
-        /// 서비스 호출
-        Long response = productService.getCountProducts(category.getValue());
-
-        /// 리턴
-        return ApiResponse.ok(response);
     }
 
 }

--- a/src/main/java/site/kikihi/custom/platform/adapter/in/web/SearchController.java
+++ b/src/main/java/site/kikihi/custom/platform/adapter/in/web/SearchController.java
@@ -1,6 +1,8 @@
 package site.kikihi.custom.platform.adapter.in.web;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import site.kikihi.custom.global.response.ApiResponse;
 import site.kikihi.custom.global.response.page.PageRequest;
@@ -32,11 +34,18 @@ public class SearchController implements SearchControllerSpec {
             @AuthenticationPrincipal PrincipalDetails principalDetails
     ) {
 
+        /// Pageable
+        Pageable pageable = org.springframework.data.domain.PageRequest.of(
+                pageRequest.getPage() - 1,
+                pageRequest.getSize(),
+                Sort.by(Sort.Direction.DESC, "id")
+        );
+
         /// 유저가 없다면 null 저장
         UUID userId = principalDetails != null ? principalDetails.getId() : null;
 
         /// 서비스 호출
-        Slice<ProductListResponse> products = service.searchProducts(keyword, pageRequest.getPage(), pageRequest.getSize(), userId);
+        Slice<ProductListResponse> products = service.searchProducts(keyword, pageable, userId);
 
         /// 서비스 호출(총 검색 결과 개수)
         long countByKeyword = service.countByKeyword(keyword);

--- a/src/main/java/site/kikihi/custom/platform/adapter/in/web/SearchController.java
+++ b/src/main/java/site/kikihi/custom/platform/adapter/in/web/SearchController.java
@@ -1,13 +1,14 @@
 package site.kikihi.custom.platform.adapter.in.web;
 
+import org.springframework.data.domain.Slice;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import site.kikihi.custom.global.response.ApiResponse;
 import site.kikihi.custom.global.response.page.PageRequest;
+import site.kikihi.custom.global.response.page.SliceResponse;
 import site.kikihi.custom.platform.adapter.in.web.dto.response.product.ProductListResponse;
 import site.kikihi.custom.platform.adapter.in.web.dto.response.search.SearchListResponse;
 import site.kikihi.custom.platform.adapter.in.web.swagger.SearchControllerSpec;
 import site.kikihi.custom.platform.application.in.search.SearchUseCase;
-import site.kikihi.custom.platform.domain.product.Product;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import site.kikihi.custom.platform.domain.search.Search;
@@ -25,7 +26,7 @@ public class SearchController implements SearchControllerSpec {
 
     /// 상품 검색
     @GetMapping
-    public ApiResponse<List<ProductListResponse>> searchProducts(
+    public ApiResponse<SliceResponse<ProductListResponse>> searchProducts(
             @RequestParam("keyword") String keyword,
             PageRequest pageRequest,
             @AuthenticationPrincipal PrincipalDetails principalDetails
@@ -35,13 +36,10 @@ public class SearchController implements SearchControllerSpec {
         UUID userId = principalDetails != null ? principalDetails.getId() : null;
 
         /// 서비스 호출
-        List<Product> productList = service.searchProducts(keyword, pageRequest.getPage(), pageRequest.getSize(), userId);
-
-        /// DTO 수정
-        List<ProductListResponse> responses = ProductListResponse.from(productList);
+        Slice<ProductListResponse> products = service.searchProducts(keyword, pageRequest.getPage(), pageRequest.getSize(), userId);
 
         /// 응답
-        return ApiResponse.ok(responses);
+        return ApiResponse.ok(SliceResponse.from(products));
     }
 
     /// 나의 최근 검색어 조회
@@ -82,49 +80,6 @@ public class SearchController implements SearchControllerSpec {
 
         /// 리턴
         return ApiResponse.deleted();
-    }
-
-    /// 자동 저장 기능 조회
-    @GetMapping("/auto")
-    public ApiResponse<String> getMyAutoSearch(
-            @AuthenticationPrincipal PrincipalDetails principalDetails
-    ) {
-
-        /// 서비스 호출
-        boolean checked = service.checkSearch(principalDetails.getId());
-
-        String autoSearch = checked ? "자동 저장이 활성화되었습니다." : "자동 저장이 꺼져있습니다.";
-
-        /// 리턴
-        return ApiResponse.ok(autoSearch);
-
-    }
-
-    /// 자동 저장 기능 켜기
-    @PutMapping("/auto/on")
-    public ApiResponse<Void> turnOnSearch(
-            @AuthenticationPrincipal PrincipalDetails principalDetails
-    ){
-
-        /// 서비스 호출
-        service.turnOnMySearchKeyword(principalDetails.getId());
-
-        /// 리턴
-        return ApiResponse.updated();
-
-    }
-
-    /// 자동 저장 기능 끄기
-    @PutMapping("/auto/off")
-    public ApiResponse<Void> turnOffSearch(
-            @AuthenticationPrincipal PrincipalDetails principalDetails
-    ){
-
-        /// 서비스 호출
-        service.turnOffMySearchKeyword(principalDetails.getId());
-
-        /// 리턴
-        return ApiResponse.updated();
     }
 
 }

--- a/src/main/java/site/kikihi/custom/platform/adapter/in/web/SearchController.java
+++ b/src/main/java/site/kikihi/custom/platform/adapter/in/web/SearchController.java
@@ -38,8 +38,11 @@ public class SearchController implements SearchControllerSpec {
         /// 서비스 호출
         Slice<ProductListResponse> products = service.searchProducts(keyword, pageRequest.getPage(), pageRequest.getSize(), userId);
 
+        /// 서비스 호출(총 검색 결과 개수)
+        long countByKeyword = service.countByKeyword(keyword);
+
         /// 응답
-        return ApiResponse.ok(SliceResponse.from(products));
+        return ApiResponse.ok(SliceResponse.from(products, countByKeyword));
     }
 
     /// 나의 최근 검색어 조회

--- a/src/main/java/site/kikihi/custom/platform/adapter/in/web/swagger/ProductControllerSpec.java
+++ b/src/main/java/site/kikihi/custom/platform/adapter/in/web/swagger/ProductControllerSpec.java
@@ -19,14 +19,6 @@ import java.util.List;
 public interface ProductControllerSpec {
 
 
-    @Operation(
-            summary = "상품 개수 조회 API",
-            description = "카테고리별 상품 전체 개수를 파악합니다."
-    )
-    ApiResponse<Long> getTotalProducts(
-            @RequestParam CategoryType category
-    );
-
     /**
      * 상품 상세 조회 API
      * @param id                상품 아이디

--- a/src/main/java/site/kikihi/custom/platform/adapter/in/web/swagger/SearchControllerSpec.java
+++ b/src/main/java/site/kikihi/custom/platform/adapter/in/web/swagger/SearchControllerSpec.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import site.kikihi.custom.global.response.ApiResponse;
 import site.kikihi.custom.global.response.page.PageRequest;
+import site.kikihi.custom.global.response.page.SliceResponse;
 import site.kikihi.custom.platform.adapter.in.web.dto.response.product.ProductListResponse;
 import site.kikihi.custom.platform.adapter.in.web.dto.response.search.SearchListResponse;
 import site.kikihi.custom.security.oauth2.domain.PrincipalDetails;
@@ -21,7 +22,7 @@ public interface SearchControllerSpec {
             summary = "검색 API",
             description = "키워드를 바탕으로 조회합니다."
     )
-    ApiResponse<List<ProductListResponse>> searchProducts(
+    ApiResponse<SliceResponse<ProductListResponse>> searchProducts(
             @Parameter(example = "하우징")
             @RequestParam("keyword") String keyword,
             PageRequest pageRequest,
@@ -57,32 +58,4 @@ public interface SearchControllerSpec {
             @AuthenticationPrincipal PrincipalDetails principalDetails
     );
 
-
-    @Operation(
-            summary = "검색어 자동저장 여부 API",
-            description = "JWT를 바탕으로 자동저장을 확인합니다."
-    )
-    ApiResponse<String> getMyAutoSearch(
-            @AuthenticationPrincipal PrincipalDetails principalDetails
-    );
-
-
-    @Operation(
-            summary = "검색어 자동저장 기능 ON API",
-            description = "JWT를 바탕으로 자동저장을 킵니다."
-    )
-    ApiResponse<Void> turnOnSearch(
-            @AuthenticationPrincipal PrincipalDetails principalDetails
-    );
-
-
-
-
-    @Operation(
-            summary = "검색어 자동저장 기능 OFF API",
-            description = "JWT를 바탕으로 자동저장을 끕니다."
-    )
-    ApiResponse<Void> turnOffSearch(
-            @AuthenticationPrincipal PrincipalDetails principalDetails
-    );
 }

--- a/src/main/java/site/kikihi/custom/platform/adapter/out/BookmarkAdapter.java
+++ b/src/main/java/site/kikihi/custom/platform/adapter/out/BookmarkAdapter.java
@@ -67,6 +67,13 @@ public class BookmarkAdapter implements BookmarkPort {
                 .toList();
     }
 
+    @Override
+    public List<Bookmark> getBookmarksByUserId(UUID userId) {
+        return repository.findByUserId(userId).stream()
+                .map(BookmarkJpaEntity::toDomain)
+                .toList();
+    }
+
     /**
      * 북마크ID 와 유저가 존재하는지 체크
      *

--- a/src/main/java/site/kikihi/custom/platform/adapter/out/UserAdapter.java
+++ b/src/main/java/site/kikihi/custom/platform/adapter/out/UserAdapter.java
@@ -33,9 +33,6 @@ public class UserAdapter implements UserPort {
         /// 조회
         var entity = userJpaRepository.findById(user.getId())
                 .orElseThrow(() -> new IllegalArgumentException(ErrorCode.USER_NOT_FOUND.getMessage()));
-
-        /// 자동저장 여부 수정
-        entity.updateSearch(user.isSearch());
     }
 
     @Override

--- a/src/main/java/site/kikihi/custom/platform/adapter/out/jpa/bookmark/BookmarkJpaRepository.java
+++ b/src/main/java/site/kikihi/custom/platform/adapter/out/jpa/bookmark/BookmarkJpaRepository.java
@@ -4,6 +4,7 @@ import site.kikihi.custom.platform.adapter.out.jpa.bookmark.projection.ProductId
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import site.kikihi.custom.platform.domain.bookmark.Bookmark;
 
 import java.util.List;
 import java.util.UUID;
@@ -35,4 +36,5 @@ public interface BookmarkJpaRepository extends JpaRepository<BookmarkJpaEntity, 
     Long countByProductId();
 
 
+    List<BookmarkJpaEntity> findByUserId(UUID userId);
 }

--- a/src/main/java/site/kikihi/custom/platform/adapter/out/jpa/user/UserJpaEntity.java
+++ b/src/main/java/site/kikihi/custom/platform/adapter/out/jpa/user/UserJpaEntity.java
@@ -41,8 +41,6 @@ public class UserJpaEntity extends BaseTimeEntity {
     @Embedded
     private AddressJpaEntity address;
 
-    private boolean isSearch;
-
     @PrePersist
     public void generateUUID() {
         if (this.id == null) {
@@ -61,7 +59,6 @@ public class UserJpaEntity extends BaseTimeEntity {
                 .role(user.getRole())
                 .profileImage(user.getProfileImage())
                 .address(AddressJpaEntity.from(user.getAddress()))
-                .isSearch(user.isSearch())
                 .build();
     }
 
@@ -76,12 +73,7 @@ public class UserJpaEntity extends BaseTimeEntity {
                 .role(role)
                 .profileImage(profileImage)
                 .address(address.toDomain())
-                .isSearch(isSearch)
                 .build();
     }
 
-    /// 엔티티 수정용
-    public void updateSearch(boolean isSearch) {
-        this.isSearch = isSearch;
-    }
 }

--- a/src/main/java/site/kikihi/custom/platform/application/in/search/SearchUseCase.java
+++ b/src/main/java/site/kikihi/custom/platform/application/in/search/SearchUseCase.java
@@ -23,6 +23,9 @@ public interface SearchUseCase {
     /// 나의 검색에 목록 확인하기
     List<Search> getMySearches(UUID userId);
 
+    /// 키워드 검색 결과 개수
+    long countByKeyword(String keyword);
+
     /// 키워드 하나 삭제하기
     void deleteMySearchKeyword(Long searchId, UUID userId);
 

--- a/src/main/java/site/kikihi/custom/platform/application/in/search/SearchUseCase.java
+++ b/src/main/java/site/kikihi/custom/platform/application/in/search/SearchUseCase.java
@@ -1,8 +1,8 @@
 package site.kikihi.custom.platform.application.in.search;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import site.kikihi.custom.platform.adapter.in.web.dto.response.product.ProductListResponse;
-import site.kikihi.custom.platform.domain.product.Product;
 import site.kikihi.custom.platform.domain.search.Search;
 
 import java.util.List;
@@ -18,7 +18,7 @@ import java.util.UUID;
 public interface SearchUseCase {
 
     /// 검색
-    Slice<ProductListResponse> searchProducts(String keyword, int page, int size, UUID userId);
+    Slice<ProductListResponse> searchProducts(String keyword, Pageable pageable, UUID userId);
 
     /// 나의 검색에 목록 확인하기
     List<Search> getMySearches(UUID userId);

--- a/src/main/java/site/kikihi/custom/platform/application/in/search/SearchUseCase.java
+++ b/src/main/java/site/kikihi/custom/platform/application/in/search/SearchUseCase.java
@@ -1,5 +1,7 @@
 package site.kikihi.custom.platform.application.in.search;
 
+import org.springframework.data.domain.Slice;
+import site.kikihi.custom.platform.adapter.in.web.dto.response.product.ProductListResponse;
 import site.kikihi.custom.platform.domain.product.Product;
 import site.kikihi.custom.platform.domain.search.Search;
 
@@ -16,7 +18,7 @@ import java.util.UUID;
 public interface SearchUseCase {
 
     /// 검색
-    List<Product> searchProducts(String keyword, int page, int size, UUID userId);
+    Slice<ProductListResponse> searchProducts(String keyword, int page, int size, UUID userId);
 
     /// 나의 검색에 목록 확인하기
     List<Search> getMySearches(UUID userId);
@@ -26,15 +28,4 @@ public interface SearchUseCase {
 
     /// 키워드 모두 삭제하기
     void deleteAllKeywords(UUID userId);
-
-    /// 나의 최근 검색어 여부
-    boolean checkSearch(UUID userId);
-
-    /// 나의 최근 검색어 저장 끄기
-    void turnOffMySearchKeyword(UUID userId);
-
-    /// 나의 최근 검색어 저장 켜기
-    void turnOnMySearchKeyword(UUID userId);
-
-
 }

--- a/src/main/java/site/kikihi/custom/platform/application/out/bookmark/BookmarkPort.java
+++ b/src/main/java/site/kikihi/custom/platform/application/out/bookmark/BookmarkPort.java
@@ -29,6 +29,8 @@ public interface BookmarkPort {
     /// 유저와 카테고리 ID를 바탕으로 북마크 목록 조회
     List<Bookmark> getBookmarksByUserIdAndCategoryId(UUID userId, String category);
 
+    List<Bookmark> getBookmarksByUserId(UUID userId);
+
     /// 유저와 북마크 ID를 바탕으로 북마크 여부 조회
     boolean checkBookmarkByUserIdAndId(UUID userId, Long bookmarkId);
 

--- a/src/main/java/site/kikihi/custom/platform/application/service/SearchService.java
+++ b/src/main/java/site/kikihi/custom/platform/application/service/SearchService.java
@@ -1,11 +1,17 @@
 package site.kikihi.custom.platform.application.service;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.elasticsearch.core.SearchHits;
 import site.kikihi.custom.global.response.ErrorCode;
+import site.kikihi.custom.platform.adapter.in.web.dto.response.product.ProductListResponse;
 import site.kikihi.custom.platform.adapter.out.elasticSearch.ProductESDocument;
-import site.kikihi.custom.platform.adapter.out.elasticSearch.ProductESRepository;
 import site.kikihi.custom.platform.application.in.search.SearchUseCase;
+import site.kikihi.custom.platform.application.out.bookmark.BookmarkPort;
 import site.kikihi.custom.platform.application.out.search.SearchPort;
 import site.kikihi.custom.platform.application.out.user.UserPort;
+import site.kikihi.custom.platform.domain.bookmark.Bookmark;
 import site.kikihi.custom.platform.domain.product.Product;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -21,6 +27,7 @@ import site.kikihi.custom.platform.domain.user.User;
 
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -30,18 +37,22 @@ public class SearchService implements SearchUseCase {
 
     /// 의존성
     private final ElasticsearchOperations elasticsearchOperations;
-    private final ProductESRepository productESRepository;
     private final SearchPort port;
 
     /// 외부 의존성
     private final UserPort userPort;
+    private final BookmarkPort bookmarkPort;
 
     /// 스태틱
     private final Float minScore = 0.001f;
 
     /// 키워드 검색 (name, description)
     @Override
-    public List<Product> searchProducts(String keyword, int page, int size, UUID userId) {
+    public Slice<ProductListResponse> searchProducts(String keyword, int page, int size, UUID userId) {
+
+        /// Pageable 구성
+        Pageable pageRequest = PageRequest.of(page, size);
+
         // match 쿼리 구성
         Query nameMatch = MatchQuery.of(m -> m.field("name").query(keyword))._toQuery();
         Query descMatch = MatchQuery.of(m -> m.field("description").query(keyword))._toQuery();
@@ -56,8 +67,8 @@ public class SearchService implements SearchUseCase {
         // NativeQuery
         NativeQuery query = NativeQuery.builder()
                 .withQuery(boolQuery)
-                .withPageable(PageRequest.of(page, size)) //page-> from으로 자동 변환(from=page * size)
-                .withMinScore(minScore)  // <<-- 추가됨
+                .withPageable(pageRequest)
+                .withMinScore(minScore)
                 .build();
 
         /// 로그인 한 유저가 확인한다면, 최근 검색 기록 DB에 저장하기
@@ -66,20 +77,37 @@ public class SearchService implements SearchUseCase {
             /// 유저 조회
             User user = getUser(userId);
 
-            /// 자동저장이 ON인 유저만 저장한다.
-            if (user.isSearch()) {
+            /// DB에 최신 검색어 저장하기
+            Search search = Search.of(user.getId(), keyword);
+            port.saveSearch(search);
 
-                /// DB에 최신 검색어 저장하기
-                Search search = Search.of(user.getId(), keyword);
-                port.saveSearch(search);
-            }
         }
 
-        return elasticsearchOperations.search(query, ProductESDocument.class)
-                .stream()
+        SearchHits<ProductESDocument> searchHits = elasticsearchOperations.search(query, ProductESDocument.class);
+
+        /// 결과물 출력
+        List<Product> elasticProducts = searchHits.stream()
                 .map(SearchHit::getContent)
                 .map(ProductESDocument::toDomain)
-                .collect(Collectors.toList());
+                .toList();
+
+        /// 페이징 처리
+        // 현재 페이지 결과 수
+        boolean hasNext = checkNext(page, size, searchHits);
+
+        Slice<Product> products = new SliceImpl<>(elasticProducts, pageRequest, hasNext);
+
+        return toProductListResponse(userId, products);
+    }
+
+    private boolean checkNext(int page, int size, SearchHits<ProductESDocument> searchHits) {
+
+        long totalHits = searchHits.getTotalHits();
+
+        // 현재 페이지와 size를 이용해 현재 페이지가 마지막 페이지인지 판단
+        boolean hasNext = (page + 1) * size < totalHits;
+
+        return hasNext;
     }
 
     @Override
@@ -129,47 +157,6 @@ public class SearchService implements SearchUseCase {
         port.deleteALlSearch(user.getId());
     }
 
-    @Override
-    public boolean checkSearch(UUID userId) {
-
-        /// 유저 예외 처리
-        User user = getUser(userId);
-
-        /// 유저의 여부 체크
-        return user.isSearch();
-    }
-
-
-    /**
-     * 검색 기록을 저장하지않도록 끕니다.
-     * @param userId    유저 ID
-     */
-    @Override
-    public void turnOffMySearchKeyword(UUID userId) {
-
-        /// 유저
-        User user = getUser(userId);
-
-        /// 켜져있을때만 끌 수있게
-        if (user.isSearch()) {
-            user.turnOffSearch();
-            userPort.updateUser(user);
-        }
-    }
-
-    @Override
-    public void turnOnMySearchKeyword(UUID userId) {
-        /// 유저
-        User user = getUser(userId);
-
-        /// 꺼져있을때만 켤 수있게
-        if (!user.isSearch()) {
-            user.turnOnSearch();
-            userPort.updateUser(user);
-        }
-
-    }
-
     /// 유저 조회
     private User getUser(UUID userId) {
 
@@ -183,6 +170,43 @@ public class SearchService implements SearchUseCase {
 
         return port.getSearch(searchId)
                 .orElseThrow(() -> new NoSuchElementException(ErrorCode.SEARCH_NOT_FOUND.getMessage()));
+    }
+
+
+    /**
+     * 상품 목록 조회를 진행할때, 북마크 여부를 파악하는 함수입니다.
+     * @param userId        유저 ID
+     * @param products      상품 목록
+     */
+    private Slice<ProductListResponse> toProductListResponse(UUID userId, Slice<Product> products) {
+        /// 응답 값
+        List<ProductListResponse> dtoList;
+
+        /// 상품 목록 꺼내서 DTO 변환
+        List<Product> content = products.getContent();
+
+        /// 로그인 하지 않은 유저가 확인한다면
+        if (userId == null) {
+
+            /// 하트가 전부 false 되는 로직
+            dtoList = ProductListResponse.from(content);
+
+            /// 새로운 Slice 객체로 생성
+            return new SliceImpl<>(dtoList, products.getPageable(), products.hasNext());
+        }
+
+        /// 유저가 북마크를 했는지 체크
+        List<Bookmark> bookmarks = bookmarkPort.getBookmarksByUserId(userId);
+
+        /// 북마크된 상품 ID만 추출
+        Set<String> bookmarkedProductIds = bookmarks.stream()
+                .map(Bookmark::getProductId)
+                .collect(Collectors.toSet());
+
+        // 북마크 여부 반영하여 DTO 변환
+        dtoList = ProductListResponse.from(content, bookmarkedProductIds);
+
+        return new SliceImpl<>(dtoList, products.getPageable(), products.hasNext());
     }
 
 }

--- a/src/main/java/site/kikihi/custom/platform/application/service/SearchService.java
+++ b/src/main/java/site/kikihi/custom/platform/application/service/SearchService.java
@@ -157,6 +157,35 @@ public class SearchService implements SearchUseCase {
         port.deleteALlSearch(user.getId());
     }
 
+    /**
+     * 키워드에 따른 검색으로 검색 결과가 몇 개인지
+     * @param keyword   키워드
+     */
+    @Override
+    public long countByKeyword(String keyword) {
+        // match 쿼리 구성
+        Query nameMatch = MatchQuery.of(m -> m.field("name").query(keyword))._toQuery();
+        Query descMatch = MatchQuery.of(m -> m.field("description").query(keyword))._toQuery();
+
+        // bool 쿼리
+        Query boolQuery = BoolQuery.of(b -> b
+                .should(nameMatch)
+                .should(descMatch)
+                .minimumShouldMatch("1")
+        )._toQuery();
+
+        // NativeQuery - 페이징 없이 전체 개수 조회용
+        NativeQuery query = NativeQuery.builder()
+                .withQuery(boolQuery)
+                .withMinScore(minScore)
+                .build();
+
+        SearchHits<ProductESDocument> searchHits = elasticsearchOperations.search(query, ProductESDocument.class);
+
+        return searchHits.getTotalHits();
+    }
+
+
     /// 유저 조회
     private User getUser(UUID userId) {
 

--- a/src/main/java/site/kikihi/custom/platform/application/service/SearchService.java
+++ b/src/main/java/site/kikihi/custom/platform/application/service/SearchService.java
@@ -14,7 +14,6 @@ import site.kikihi.custom.platform.application.out.user.UserPort;
 import site.kikihi.custom.platform.domain.bookmark.Bookmark;
 import site.kikihi.custom.platform.domain.product.Product;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHit;
@@ -48,10 +47,9 @@ public class SearchService implements SearchUseCase {
 
     /// 키워드 검색 (name, description)
     @Override
-    public Slice<ProductListResponse> searchProducts(String keyword, int page, int size, UUID userId) {
+    public Slice<ProductListResponse> searchProducts(String keyword, Pageable pageable, UUID userId) {
 
         /// Pageable 구성
-        Pageable pageRequest = PageRequest.of(page, size);
 
         // match 쿼리 구성
         Query nameMatch = MatchQuery.of(m -> m.field("name").query(keyword))._toQuery();
@@ -67,7 +65,7 @@ public class SearchService implements SearchUseCase {
         // NativeQuery
         NativeQuery query = NativeQuery.builder()
                 .withQuery(boolQuery)
-                .withPageable(pageRequest)
+                .withPageable(pageable)
                 .withMinScore(minScore)
                 .build();
 
@@ -93,9 +91,9 @@ public class SearchService implements SearchUseCase {
 
         /// 페이징 처리
         // 현재 페이지 결과 수
-        boolean hasNext = checkNext(page, size, searchHits);
+        boolean hasNext = checkNext(pageable.getPageNumber(), pageable.getPageSize(), searchHits);
 
-        Slice<Product> products = new SliceImpl<>(elasticProducts, pageRequest, hasNext);
+        Slice<Product> products = new SliceImpl<>(elasticProducts, pageable, hasNext);
 
         return toProductListResponse(userId, products);
     }

--- a/src/main/java/site/kikihi/custom/platform/domain/user/User.java
+++ b/src/main/java/site/kikihi/custom/platform/domain/user/User.java
@@ -24,7 +24,6 @@ public class User {
     private Role role;
     private String profileImage;
     private Address address;
-    private boolean isSearch = true;
 
     /// 정적 팩토리 메서드
     public static User of(OAuth2UserInfo userInfo) {
@@ -38,17 +37,7 @@ public class User {
                 .profileImage(userInfo.getImageUrl())
                 .role(Role.USER)
                 .address(Address.of())
-                .isSearch(true)
                 .build();
-    }
-
-    /// 비즈니스 로직
-    public void turnOnSearch() {
-        isSearch = true;
-    }
-
-    public void turnOffSearch() {
-        isSearch = false;
     }
 
 }


### PR DESCRIPTION
## 📌 작업한 내용  
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
- 기존 개별 상품 전체 개수 조회 API를 목록 조회 API에 통합하여 효율성 및 응답 일관성 향상
- SliceResponse에 전체 개수(totalCount) 필드 추가 및 전체 개수 포함 응답 처리 구현
- ProductController의 목록 조회 메서드에서 카테고리별 전체 상품 개수를 조회하여 응답에 포함하도록 수정
- 불필요한 별도 전체 개수 조회 API 및 관련 스펙 삭제
- 불필요한 자동저장 기능 제거 및 Slice 구조 변경에 따른 코드 정리

## 🔍 참고 사항  
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->
x

## 🖼️ 스크린샷  
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

- 검색
<img width="1439" height="292" alt="image" src="https://github.com/user-attachments/assets/bfc40658-f927-4f2d-87fc-f433f47bf815" />

- 상품
<img width="1434" height="240" alt="image" src="https://github.com/user-attachments/assets/7a9aff27-ebc3-44c6-b4ea-223552f9a096" />


## 🔗 관련 이슈  
<!-- 연관된 이슈를 적어주세요. -->
#77 

## ✅ 체크리스트  
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료  
- [ ] 코드 리뷰 반영 완료  
- [x] 문서화 필요 여부 확인
